### PR TITLE
feat(auth): integrar frontend com rotas /login e /register do backend

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
+
+O formato é baseado em [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
+e este projeto segue [Conventional Commits](https://www.conventionalcommits.org/).
+
+## [Unreleased]
+
+### Added
+- **auth**: integração do frontend com rotas reais do backend:
+  - `POST /api/user/login` para autenticação com JWT
+  - `POST /api/user/register` para criação de novos usuários
+- **AuthProvider**:
+  - Implementado método `login()` que persiste o token no `localStorage` e adiciona `Authorization` no axios
+  - Implementado método `register()` para enviar dados de cadastro ao backend
+  - Ajustado método `logout()` para limpar sessão
+- **Cadastro.jsx**:
+  - Integração com `register()` do AuthProvider
+  - Validação de campos obrigatórios (nome, sobrenome, cpf, email, senha)
+  - Redirecionamento automático para `/login` após cadastro bem-sucedido
+
+### Changed
+- Tela de cadastro ajustada para atender aos contratos esperados pelo backend
+
+### Fixed
+- Corrigido fluxo de autenticação: token agora é salvo corretamente após login

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -4,6 +4,11 @@ import { useNavigate } from "react-router-dom";
 import axios from "axios";
 import { AuthContext } from "./context";
 
+
+const API = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:3000",
+});
+
 export default function AuthProvider({ children }) {
   const [token, setToken] = useState(null);
   const [user, setUser]   = useState(null);
@@ -21,38 +26,87 @@ export default function AuthProvider({ children }) {
     setIsBooting(false);
   }, []);
 
-//   async function login({ email, password }) {
-//   try {
-//     const res = await axios.post("http://localhost:3000/auth/login", {
-//       email,
-//       password,
-//     });
+  async function register({ nome, sobrenome, cpf, email, password, telefone }) {
+  try {
+    const res = await axios.post("http://localhost:3000/api/user/register", {
+      nome,
+      sobrenome,
+      cpf,
+      email,
+      senha: password,   // 👈 o back espera "senha"
+      telefone,          // 👈 opcional
+    });
 
-//     const { token } = res.data; // backend deve retornar { token: "..." }
-//     localStorage.setItem("authToken", token);
-//     setToken(token);
-//     axios.defaults.headers.common.Authorization = `Bearer ${token}`;
+    // se o back retornar mensagem de sucesso
+    if (res.data?.message) {
+      console.log(res.data.message);
+      navigate("/login", { replace: true });
+    }
+  } catch (err) {
+    console.error("[Auth] erro no registro", err);
+    const msg =
+      err?.response?.data?.error ||
+      err?.response?.data?.message ||
+      err.message ||
+      "Falha no registro.";
+    throw new Error(msg);
+  }
+}
 
-//     // opcional: buscar dados do usuário
-//     // const me = await axios.get("http://localhost:3000/auth/me");
-//     // setUser(me.data);
+  // src/auth/AuthProvider.jsx (trecho do login)
+async function login({ email, password }) {
+  try {
+    // ⚠️ seu back recebe 'senha'
+    const res = await axios.post("http://localhost:3000/api/user/login", {
+      email,
+      senha: password,
+    });
 
-//     navigate("/agenda", { replace: true });
-//   } catch (err) {
-//     console.error("[Auth] erro no login", err);
-//     throw err;
-//   }
-// }
+    // 🔎 tente várias chaves comuns / formatos aninhados
+    const jwt =
+      res.data?.token ??
+      res.data?.accessToken ??
+      res.data?.jwt ??
+      res.data?.data?.token ??
+      res.data?.data?.accessToken ??
+      res.data?.data?.jwt;
+
+    if (!jwt) {
+      // não salva nada se não houver token; loga p/ inspecionar a resposta
+      console.log("[Auth] login response sem token:", res.data);
+      throw new Error("Token não retornado pelo servidor.");
+    }
+
+    localStorage.setItem("authToken", jwt);
+    axios.defaults.headers.common.Authorization = `Bearer ${jwt}`;
+
+    setToken(jwt);
+    // opcional:
+    // const me = await axios.get("http://localhost:3000/api/user/me");
+    // setUser(me.data);
+
+    navigate("/agenda", { replace: true });
+  } catch (err) {
+    // garante que não fica lixo no storage se falhar
+    localStorage.removeItem("authToken");
+    delete axios.defaults.headers.common.Authorization;
+
+    const msg = err?.response?.data?.message || err.message || "Falha no login.";
+    console.error("[Auth] erro no login:", err);
+    throw new Error(msg);
+  }
+}
+
 
 
   // MOCK de login (troque por chamada real quando tiver backend)
-  async function loginMock() {
-    const fake = "fake-token-123";
-    localStorage.setItem("authToken", fake);
-    setToken(fake);
-    axios.defaults.headers.common.Authorization = `Bearer ${fake}`;
-    navigate("/agenda", { replace: true });
-  }
+  // async function loginMock() {
+  //   const fake = "fake-token-123";
+  //   localStorage.setItem("authToken", fake);
+  //   setToken(fake);
+  //   axios.defaults.headers.common.Authorization = `Bearer ${fake}`;
+  //   navigate("/agenda", { replace: true });
+  // }
 
   function logout() {
     localStorage.removeItem("authToken");
@@ -66,9 +120,10 @@ export default function AuthProvider({ children }) {
     token,
     user,
     isBooting,
-    login: loginMock,
-    //login,
+    //login: loginMock,
+    login,
     logout,
+    register,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/src/pages/Cadastro/Cadastro.jsx
+++ b/src/pages/Cadastro/Cadastro.jsx
@@ -1,7 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { useAuth } from "../../auth/useAuth";
 
 export default function Cadastro() {
+  const { register } = useAuth();
+
   const [form, setForm] = useState({
     nome: "",
     sobrenome: "",
@@ -14,33 +17,43 @@ export default function Cadastro() {
   const [showPass, setShowPass] = useState(false);
   const [errors, setErrors] = useState({});
   const [success, setSuccess] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   const handleChange = (e) => {
     setForm((prev) => ({ ...prev, [e.target.name]: e.target.value }));
     setErrors((prev) => ({ ...prev, [e.target.name]: "" }));
+    setSubmitError("");
+    setSuccess("");
   };
 
-  // ✅ Função específica para o campo de documento
+  // ✅ Campo de documento (apenas dígitos, máx 14)
   const handleDocumentChange = (e) => {
-    const value = e.target.value.replace(/\D/g, ""); // Remove não-dígitos
-    const limitedValue = value.slice(0, 14); // Limita em 14 caracteres
+    const value = e.target.value.replace(/\D/g, "");
+    const limitedValue = value.slice(0, 14);
     setForm((prev) => ({ ...prev, documento: limitedValue }));
     setErrors((prev) => ({ ...prev, documento: "" }));
+    setSubmitError("");
+    setSuccess("");
   };
 
   const validate = () => {
     const errs = {};
     if (!form.nome.trim()) errs.nome = "Informe o nome.";
     if (!form.sobrenome.trim()) errs.sobrenome = "Informe o sobrenome.";
+
     if (!form.email.trim()) errs.email = "Informe o e-mail.";
     else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email))
       errs.email = "E-mail inválido.";
+
     if (!form.senha || form.senha.length < 6)
       errs.senha = "A senha deve ter no mínimo 6 caracteres.";
+
     if (form.senha !== form.confirmarSenha)
       errs.confirmarSenha = "As senhas não coincidem.";
 
-    // ✅ Validação de documento mais robusta
+    // Mantive sua regra: 11 (CPF) OU 14 (CNPJ).
+    // Se quiser forçar só CPF (11), troque a condição.
     if (!form.documento.trim()) {
       errs.documento = "Informe o CPF ou CNPJ.";
     } else if (form.documento.length !== 11 && form.documento.length !== 14) {
@@ -49,18 +62,38 @@ export default function Cadastro() {
 
     if (form.contato && form.contato.length < 8)
       errs.contato = "Contato muito curto (mín. 8 dígitos).";
+
     return errs;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setSuccess("");
+    setSubmitError("");
     const v = validate();
     setErrors(v);
     if (Object.keys(v).length > 0) return;
 
-    console.log("Cadastro enviado:", form);
-    setSuccess("Cadastro realizado com sucesso!");
+    setSubmitting(true);
+    try {
+      // Mapeia para o formato do backend
+      await register({
+        nome: form.nome,
+        sobrenome: form.sobrenome,
+        cpf: form.documento,        // 👈 back espera "cpf"
+        email: form.email,
+        password: form.senha,       // 👈 será enviado como "senha" no AuthProvider
+        telefone: form.contato || undefined, // opcional
+      });
+
+      // Se o back só retorna mensagem e o AuthProvider navega para /login,
+      // este success pode nem aparecer, mas deixei caso mude o fluxo
+      setSuccess("Cadastro realizado com sucesso! Redirecionando para o login…");
+    } catch (err) {
+      setSubmitError(err.message || "Falha no cadastro.");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -73,27 +106,45 @@ export default function Cadastro() {
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M15 19l-7-7 7-7"/>
         </svg>
       </Link>
+
       <div className="w-full max-w-lg">
         <div className="text-center mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Cadastro</h1>
           <p className="text-gray-400">Preencha seus dados para começar</p>
         </div>
+
         <div className="card p-8 rounded-2xl">
           <form className="space-y-5" onSubmit={handleSubmit} noValidate>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              {/* Nome e Sobrenome aqui... */}
               <div>
                 <label className="block text-left text-sm font-medium text-white mb-2">Nome</label>
-                <input type="text" name="nome" value={form.nome} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.nome ? "border-red-600" : ""}`} placeholder="Seu nome" />
-                {errors.nome && (<p className="mt-1 text-sm text-red-500">{errors.nome}</p>)}
+                <input
+                  type="text"
+                  name="nome"
+                  value={form.nome}
+                  onChange={handleChange}
+                  className={`input-field w-full px-4 py-3 rounded-lg ${errors.nome ? "border-red-600" : ""}`}
+                  placeholder="Seu nome"
+                  autoComplete="given-name"
+                />
+                {errors.nome && <p className="mt-1 text-sm text-red-500">{errors.nome}</p>}
               </div>
+
               <div>
                 <label className="block text-left text-sm font-medium text-white mb-2">Sobrenome</label>
-                <input type="text" name="sobrenome" value={form.sobrenome} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.sobrenome ? "border-red-600" : ""}`} placeholder="Seu sobrenome"/>
-                {errors.sobrenome && (<p className="mt-1 text-sm text-red-500">{errors.sobrenome}</p>)}
+                <input
+                  type="text"
+                  name="sobrenome"
+                  value={form.sobrenome}
+                  onChange={handleChange}
+                  className={`input-field w-full px-4 py-3 rounded-lg ${errors.sobrenome ? "border-red-600" : ""}`}
+                  placeholder="Seu sobrenome"
+                  autoComplete="family-name"
+                />
+                {errors.sobrenome && <p className="mt-1 text-sm text-red-500">{errors.sobrenome}</p>}
               </div>
             </div>
-            
+
             {/* CPF/CNPJ */}
             <div>
               <label className="block text-left text-sm font-medium text-white mb-2">CPF ou CNPJ</label>
@@ -101,40 +152,98 @@ export default function Cadastro() {
                 type="text"
                 name="documento"
                 value={form.documento}
-                onChange={handleDocumentChange} // ✅ Usando a nova função
+                onChange={handleDocumentChange}
                 className={`input-field w-full px-4 py-3 rounded-lg ${errors.documento ? "border-red-600" : ""}`}
                 placeholder="Apenas números"
                 inputMode="numeric"
+                autoComplete="off"
               />
-              {errors.documento && (<p className="mt-1 text-sm text-red-500">{errors.documento}</p>)}
+              {errors.documento && <p className="mt-1 text-sm text-red-500">{errors.documento}</p>}
             </div>
 
-            {/* Contato, Email, Senha, Confirmar Senha aqui... */}
+            {/* Contato */}
             <div>
-                <label className="block text-left text-sm font-medium text-white mb-2">Contato (opcional)</label>
-                <input type="text" name="contato" value={form.contato} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.contato ? "border-red-600" : ""}`} placeholder="(DDD) 90000-0000"/>
-                {errors.contato && (<p className="mt-1 text-sm text-red-500">{errors.contato}</p>)}
+              <label className="block text-left text-sm font-medium text-white mb-2">Contato (opcional)</label>
+              <input
+                type="text"
+                name="contato"
+                value={form.contato}
+                onChange={handleChange}
+                className={`input-field w-full px-4 py-3 rounded-lg ${errors.contato ? "border-red-600" : ""}`}
+                placeholder="(DDD) 90000-0000"
+                inputMode="tel"
+                autoComplete="tel"
+              />
+              {errors.contato && <p className="mt-1 text-sm text-red-500">{errors.contato}</p>}
             </div>
+
+            {/* Email */}
             <div>
-                <label className="block text-left text-sm font-medium text-white mb-2">E-mail</label>
-                <input type="email" name="email" value={form.email} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.email ? "border-red-600" : ""}`} placeholder="seu@email.com"/>
-                {errors.email && (<p className="mt-1 text-sm text-red-500">{errors.email}</p>)}
+              <label className="block text-left text-sm font-medium text-white mb-2">E-mail</label>
+              <input
+                type="email"
+                name="email"
+                value={form.email}
+                onChange={handleChange}
+                className={`input-field w-full px-4 py-3 rounded-lg ${errors.email ? "border-red-600" : ""}`}
+                placeholder="seu@email.com"
+                autoComplete="email"
+              />
+              {errors.email && <p className="mt-1 text-sm text-red-500">{errors.email}</p>}
             </div>
+
+            {/* Senhas */}
             <div>
-                <label className="block text-sm font-medium text-white mb-2">Senha</label>
-                <input type={showPass ? "text" : "password"} name="senha" value={form.senha} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.senha ? "border-red-600" : ""}`} placeholder="Crie uma senha"/>
-                {errors.senha && (<p className="mt-1 text-sm text-red-500">{errors.senha}</p>)}
+              <label className="block text-sm font-medium text-white mb-2">Senha</label>
+              <input
+                type={showPass ? "text" : "password"}
+                name="senha"
+                value={form.senha}
+                onChange={handleChange}
+                className={`input-field w-full px-4 py-3 rounded-lg ${errors.senha ? "border-red-600" : ""}`}
+                placeholder="Crie uma senha"
+                autoComplete="new-password"
+              />
+              {errors.senha && <p className="mt-1 text-sm text-red-500">{errors.senha}</p>}
             </div>
+
             <div>
-                <label className="block text-sm font-medium text-white mb-2">Confirmar Senha</label>
-                <input type={showPass ? "text" : "password"} name="confirmarSenha" value={form.confirmarSenha} onChange={handleChange} className={`input-field w-full px-4 py-3 rounded-lg ${errors.confirmarSenha ? "border-red-600" : ""}`} placeholder="Confirme sua senha"/>
-                {errors.confirmarSenha && (<p className="mt-1 text-sm text-red-500">{errors.confirmarSenha}</p>)}
+              <label className="block text-sm font-medium text-white mb-2">Confirmar Senha</label>
+              <input
+                type={showPass ? "text" : "password"}
+                name="confirmarSenha"
+                value={form.confirmarSenha}
+                onChange={handleChange}
+                className={`input-field w-full px-4 py-3 rounded-lg ${errors.confirmarSenha ? "border-red-600" : ""}`}
+                placeholder="Confirme sua senha"
+                autoComplete="new-password"
+              />
+              {errors.confirmarSenha && <p className="mt-1 text-sm text-red-500">{errors.confirmarSenha}</p>}
             </div>
+
+            {/* Mostrar/ocultar senha */}
             <div className="text-left">
-                <button type="button" onClick={() => setShowPass((s) => !s)} className="text-sm text-gray-300 hover:text-white">{showPass ? "Ocultar senhas" : "Mostrar senhas"}</button>
+              <button
+                type="button"
+                onClick={() => setShowPass((s) => !s)}
+                className="text-sm text-gray-300 hover:text-white"
+              >
+                {showPass ? "Ocultar senhas" : "Mostrar senhas"}
+              </button>
             </div>
-            <button type="submit" className="btn-primary w-full py-3 rounded-lg font-semibold text-base">Criar conta</button>
-            {success && (<div className="mt-2 text-sm text-green-400">{success}</div>)}
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={submitting}
+              className="btn-primary w-full py-3 rounded-lg font-semibold text-base disabled:opacity-60"
+            >
+              {submitting ? "Criando conta..." : "Criar conta"}
+            </button>
+
+            {/* Feedback */}
+            {submitError && <div className="mt-2 text-sm text-red-400">{submitError}</div>}
+            {success && <div className="mt-2 text-sm text-green-400">{success}</div>}
           </form>
         </div>
       </div>


### PR DESCRIPTION
### O que foi feito
- Ajustado AuthProvider para consumir a rota `POST /api/user/login`
  - Salva token no localStorage
  - Configura axios com header Authorization
- Criado método `register()` no AuthProvider para consumir `POST /api/user/register`
- Atualizada tela de Cadastro:
  - Validação de campos
  - Integração com register() do contexto
  - Redirecionamento para /login após sucesso

### Motivação
Integrar o fluxo de autenticação do frontend com o backend real, eliminando mocks.

### Critérios de Aceite
- [x] Usuário consegue registrar-se e é redirecionado ao login
- [x] Usuário consegue logar e ver token salvo no localStorage
- [x] Logout limpa sessão e volta ao login
