### PR TITLE
Feat/intregação lib

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+VITE_USE_MOCK_AUTH=true
+VITE_API_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -34,3 +34,27 @@ Este projeto utiliza **Node.js v20.19.0**.
 ```bash
 nvm use
 
+## Ambiente / Execução
+
+Este projeto suporta **dois modos de execução**:
+Este projeto usa cross-env para configurar variáveis de ambiente nos scripts.
+O pacote já está listado no package.json, portanto todos os membros da equipe só precisam rodar após dar o pull
+    `
+    ``bash
+    npm install 
+
+---
+
+### 🔹 1) Modo Mock (sem backend)
+Utiliza respostas simuladas direto no front (útil para desenvolvimento rápido sem precisar do backend rodando).
+
+- Variável de ambiente: `VITE_USE_MOCK_AUTH=true`
+- Script:
+  ```bash
+  npm run dev:mock
+
+### 🔹 2) Modo Mock (com backend)
+    - Variável de ambiente: `VITE_API_URL=http://localhost:3000`
+    - Script:
+  ```bash
+  npm run dev:real

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
         "autoprefixer": "^10.4.21",
+        "cross-env": "^10.0.0",
         "eslint": "^9.33.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
@@ -345,6 +346,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.9",
@@ -2101,6 +2109,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "dev:mock": "cross-env VITE_USE_MOCK_AUTH=true vite",
+    "dev:real": "cross-env VITE_USE_MOCK_AUTH=false VITE_API_URL=http://localhost:3000 vite"
   },
   "dependencies": {
     "axios": "^1.11.0",
@@ -27,6 +29,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
+    "cross-env": "^10.0.0",
     "eslint": "^9.33.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,14 +1,20 @@
 import { loadAuth, clearAuth, saveAuth } from "../auth/auth-storage";
 
 const baseURL = import.meta?.env?.VITE_API_URL || "http://localhost:3000";
-const USE_MOCK = import.meta?.env?.VITE_USE_MOCK_AUTH === "true";
-const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+const USE_MOCK = String(import.meta?.env?.VITE_USE_MOCK_AUTH || "").trim().toLowerCase() === "true";
+
+console.debug("[api] VITE_USE_MOCK_AUTH raw =", import.meta.env.VITE_USE_MOCK_AUTH);
+console.debug("[api] USE_MOCK computed =", USE_MOCK);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 let refreshing = null;
 
 
 export async function apiFetch(path, options = {}) {
+  console.debug("[apiFetch] USE_MOCK:", USE_MOCK, "path:", path, "method:", options.method || "GET");
+
   if (USE_MOCK) {
     return mockApiFetch(path, options);
   }


### PR DESCRIPTION
## Alternância entre ambiente Mock e Real com `cross-env`

Esta PR adiciona dois scripts que permitem rodar o front usando **dados mockados** ou **backend real**, apenas trocando o comando. A alternância é feita via variável `VITE_USE_MOCK_AUTH` configurada com **cross-env** (compatível com Windows, macOS e Linux).

### Comandos
- `npm run dev:mock` → **Login mockado** (usa `mockApiFetch` em `src/lib/api.js`)
- `npm run dev:real` → **Login com backend**

### Scripts adicionados (package.json)
```json
{
  "scripts": {
    "dev:mock": "cross-env VITE_USE_MOCK_AUTH=true VITE_API_URL=http://localhost:3000 vite",
    "dev:real": "cross-env VITE_USE_MOCK_AUTH=false VITE_API_URL=http://localhost:3000 vite"
  },
  "devDependencies": {
    "cross-env": "^7.0.3"
  }
}
