### PR TITLE
chore(git): ignorar arquivos .env e remover do índice

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,0 @@
-VITE_USE_MOCK_AUTH=false
-VITE_API_URL=http://localhost:3000
-VITE_PUBLIC_BUCKET_URL=https://pub-a2e43516b1984deb95bc4adfd3070bed.r2.dev
-VITE_USE_MOCK=false

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment files
+.env
+.env.*
+!.env.example


### PR DESCRIPTION
### Remoção do `.env` do Repositório

#### Objetivo
Parar de versionar o arquivo `.env` sem a necessidade de reescrever o histórico do repositório.

---

#### Ações Realizadas

1.  **Adicionado ao `.gitignore`:**
    ```
    .env
    .env.*
    !.env.example
    ```

2.  **Removido o `.env` do índice do Git (sem apagar o arquivo localmente):**
    ```sh
    git rm --cached .env
    ```

3.  **Commit criado e enviado:**
    - **Branch:** `fix/retirar-env`
    - **Commit:**
      ```
      chore(git): ignorar arquivos .env e remover do índice
      ```
    - **PR:** `https://github.com/yasmin-code-tech/tattoali-Front-end-/pull/new/fix/retirar-env`

---

#### Impacto

- O arquivo `.env` permanecerá no seu disco local, mas não será mais rastreado pelo Git.
- O `.env` deixará de ser incluído em commits futuros.
- **Atenção:** Commits antigos ainda contêm o arquivo `.env`. Como não continha segredos sensíveis, a reescrita do histórico não foi necessária.

---

#### Comando Explicado

- `git rev-parse --abbrev-ref HEAD`: Utilizado para confirmar o nome da branch atual antes de configurar o *upstream* no `push`.

---
